### PR TITLE
Update geneRegionsStr helper in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -370,11 +370,12 @@ router.post('/getIdColumns', async (ctx) => {
     const params = JSON.parse(ctx.request.body);
     console.log(JSON.stringify(params, null, 2));
 
-    const regionStr = genRegionsStr(params.regions);
+    const regionStr = genRegionsStr(params.regions, ",");
     const args = [
         params.vcfUrl, regionStr
     ];
 
+    console.log(regionStr);
     await handle(ctx, 'getIdColumns.sh', args, { ignoreStderr: true });
 });
 
@@ -440,7 +441,7 @@ function genRegionStr(region) {
   return region.refName + ':' + region.start + '-' + region.end;
 }
 
-function genRegionsStr(regions) {
+function genRegionsStr(regions, delim = " ") {
   let regionStr = "";
   for (const region of regions) {
 
@@ -450,10 +451,11 @@ function genRegionsStr(regions) {
       regionStr += ':' + region.start;
 
       if (region.end) {
-        regionStr += '-' + region.end + " ";
+        regionStr += '-' + region.end + delim;
       }
     }
   }
+  regionStr = regionStr.substring(0, regionStr.length - 1);
   return regionStr;
 }
 


### PR DESCRIPTION
Bcftools view would not pull back multiple regions when I used spaces as delimiter for regions argument with >1 region. Just made an optional parameter for genRegionsStr so it could accept custom delimiter. Still defaults to spaces.